### PR TITLE
Add sentence-transformer clustering encoder and training script

### DIFF
--- a/cluster/__init__.py
+++ b/cluster/__init__.py
@@ -1,0 +1,9 @@
+from .embedding import encode_texts, load_encoder
+from .pipeline import cluster_keywords, run_pipeline
+
+__all__ = [
+    "encode_texts",
+    "load_encoder",
+    "cluster_keywords",
+    "run_pipeline",
+]

--- a/cluster/embedding.py
+++ b/cluster/embedding.py
@@ -1,0 +1,112 @@
+"""Utility helpers for working with the sentence-transformer encoder.
+
+The project relies on a sentence-transformer model that has been fine-tuned
+with a triplet loss objective on curated (anchor, positive, negative) keyword
+examples.  The fine-tuned weights are expected to live in
+``cluster/models/intent-encoder`` or a path supplied through the
+``INTENT_ENCODER_PATH`` environment variable.  When those weights are not
+available the helpers gracefully fall back to the base model so the rest of the
+pipeline can still operate, albeit with lower quality clusters.
+"""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+DEFAULT_BASE_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+DEFAULT_FINETUNED_DIR = Path(__file__).resolve().parent / "models" / "intent-encoder"
+ENV_MODEL_PATH = "INTENT_ENCODER_PATH"
+
+
+def _resolve_model_path(model_path: str | os.PathLike[str] | None = None) -> Path | None:
+    """Return the most appropriate location of the fine-tuned model weights."""
+
+    if model_path is not None:
+        path = Path(model_path)
+        return path if path.exists() else None
+
+    env_path = os.environ.get(ENV_MODEL_PATH)
+    if env_path:
+        path = Path(env_path)
+        if path.exists():
+            return path
+
+    if DEFAULT_FINETUNED_DIR.exists():
+        return DEFAULT_FINETUNED_DIR
+
+    return None
+
+
+@lru_cache(maxsize=2)
+def load_encoder(model_path: str | os.PathLike[str] | None = None) -> SentenceTransformer:
+    """Load the sentence-transformer encoder used throughout the pipeline.
+
+    Parameters
+    ----------
+    model_path:
+        Optional path pointing to a directory containing the fine-tuned
+        sentence-transformer weights.  When omitted the helper looks for the
+        weights inside ``cluster/models/intent-encoder`` and finally falls back
+        to the base model shipped with SentenceTransformers.
+    """
+
+    resolved = _resolve_model_path(model_path)
+    if resolved is not None:
+        return SentenceTransformer(str(resolved))
+    return SentenceTransformer(DEFAULT_BASE_MODEL)
+
+
+def encode_texts(
+    texts: Sequence[str] | Iterable[str],
+    *,
+    normalize: bool = True,
+    batch_size: int = 32,
+    show_progress_bar: bool = False,
+    model_path: str | os.PathLike[str] | None = None,
+) -> np.ndarray:
+    """Encode a collection of texts using the fine-tuned encoder.
+
+    Parameters
+    ----------
+    texts:
+        Iterable containing the strings that need to be embedded.
+    normalize:
+        Whether to L2-normalize the resulting embeddings.  Cosine similarity and
+        HDBSCAN clustering perform better with normalized vectors, so the
+        default is ``True``.
+    batch_size:
+        Batch size forwarded to :meth:`SentenceTransformer.encode`.
+    show_progress_bar:
+        When ``True`` the underlying model will show a progress bar while
+        encoding; disabled by default to keep the command-line interface quiet.
+    model_path:
+        Optional override pointing to the model that should be used.
+
+    Returns
+    -------
+    numpy.ndarray
+        Two dimensional array where each row corresponds to the embedding of the
+        matching text input.
+    """
+
+    model = load_encoder(model_path=model_path)
+    vectors = model.encode(
+        list(texts),
+        batch_size=batch_size,
+        show_progress_bar=show_progress_bar,
+        convert_to_numpy=True,
+    )
+    if normalize:
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        # Avoid division by zero for empty or pathological vectors.
+        norms[norms == 0.0] = 1.0
+        vectors = vectors / norms
+    return vectors
+
+
+__all__ = ["load_encoder", "encode_texts", "DEFAULT_BASE_MODEL", "DEFAULT_FINETUNED_DIR"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ rapidfuzz
 scikit-learn
 numpy
 streamlit
+sentence-transformers
+torch
+hdbscan

--- a/train_encoder.py
+++ b/train_encoder.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterator
+
+import pandas as pd
+from sentence_transformers import InputExample, SentenceTransformer, losses
+from torch.utils.data import DataLoader
+
+from cluster.embedding import DEFAULT_BASE_MODEL
+
+
+TRIPLET_KEYS = {"anchor", "positive", "negative"}
+
+
+def _validate_record(record: dict[str, str], idx: int) -> tuple[str, str, str]:
+    missing = TRIPLET_KEYS.difference(record)
+    if missing:
+        raise ValueError(f"Missing keys {missing} in record {idx}")
+    return record["anchor"], record["positive"], record["negative"]
+
+
+def load_triplets(path: Path) -> Iterator[InputExample]:
+    """Yield :class:`InputExample` instances from a dataset file.
+
+    The loader accepts CSV/TSV files with ``anchor``, ``positive`` and
+    ``negative`` columns as well as JSON or JSONL files following the same key
+    structure.
+    """
+
+    suffix = path.suffix.lower()
+    if suffix in {".csv", ".tsv"}:
+        df = pd.read_csv(path)
+        if not TRIPLET_KEYS.issubset(df.columns):
+            missing = TRIPLET_KEYS.difference(df.columns)
+            raise ValueError(f"Dataset is missing required columns: {missing}")
+        for record in df[["anchor", "positive", "negative"]].itertuples(index=False):
+            yield InputExample(texts=list(record))
+        return
+
+    if suffix == ".jsonl":
+        with path.open() as f:
+            for idx, line in enumerate(f):
+                if not line.strip():
+                    continue
+                payload = json.loads(line)
+                triplet = _validate_record(payload, idx)
+                yield InputExample(texts=list(triplet))
+        return
+
+    if suffix == ".json":
+        payload = json.loads(path.read_text())
+        if not isinstance(payload, (list, tuple)):
+            raise ValueError("JSON dataset must contain an iterable of records")
+        for idx, record in enumerate(payload):
+            triplet = _validate_record(record, idx)
+            yield InputExample(texts=list(triplet))
+        return
+
+    raise ValueError(
+        "Unsupported dataset format. Provide CSV/TSV, JSON, or JSONL files with"
+        " 'anchor', 'positive', and 'negative' fields."
+    )
+
+
+def build_dataloader(examples: list[InputExample], batch_size: int) -> DataLoader:
+    if not examples:
+        raise ValueError("The training dataset is empty. Provide at least one triplet.")
+    return DataLoader(examples, shuffle=True, batch_size=batch_size)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fine-tune the clustering encoder with triplet loss")
+    parser.add_argument("--dataset", required=True, type=Path, help="Path to the curated triplet dataset")
+    parser.add_argument("--output-dir", required=True, type=Path, help="Where the fine-tuned model will be stored")
+    parser.add_argument(
+        "--pretrained-model",
+        default=DEFAULT_BASE_MODEL,
+        help="Base sentence-transformer model to start from",
+    )
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--learning-rate", type=float, default=2e-5)
+    parser.add_argument(
+        "--warmup-ratio",
+        type=float,
+        default=0.1,
+        help="Fraction of total steps used for warmup",
+    )
+    args = parser.parse_args()
+
+    examples = list(load_triplets(args.dataset))
+    dataloader = build_dataloader(examples, args.batch_size)
+
+    model = SentenceTransformer(args.pretrained_model)
+    train_loss = losses.TripletLoss(
+        model,
+        distance_metric=losses.TripletDistanceMetric.COSINE,
+        triplet_margin=0.3,
+    )
+
+    total_steps = len(dataloader) * args.epochs
+    warmup_steps = int(total_steps * args.warmup_ratio)
+
+    model.fit(
+        train_objectives=[(dataloader, train_loss)],
+        epochs=args.epochs,
+        optimizer_params={"lr": args.learning_rate},
+        warmup_steps=warmup_steps,
+        scheduler="warmuplinear",
+        show_progress_bar=True,
+    )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    model.save(str(args.output_dir))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable embedding helper that loads the fine-tuned sentence-transformer encoder
- swap the TF-IDF similarity grouping for HDBSCAN clusters computed from encoder embeddings and expose the new options in the CLI
- provide a triplet-loss fine-tuning script and declare the additional dependencies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c97d26ed308321a3f53d80a9f84cf1