### PR TITLE
Add evaluation logging and lexicon update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,78 @@
 # seo-cluster-intent-tool
-keyword
-betway register bonus
-betpawa app
-football betting tips
-betway apk ghana
-odds comparison premier league
+
+Utilities for clustering SEO keywords, assigning intents, and maintaining the lexical resources that drive the tagging heuristics.
+
+## Keyword pipeline
+
+Run the core pipeline from the command line:
+
+```bash
+python -m cluster.pipeline keywords_in.csv keywords_tagged.csv --min-sim 0.8
+```
+
+The pipeline expects a CSV with a `keyword` column and writes the augmented results to the output path.
+
+## Evaluation & maintenance workflow
+
+Maintaining high intent accuracy requires a feedback loop. The project now ships with tooling to capture misclassifications, surface unseen vocabulary, and append vetted tokens to the shared lexicon.
+
+### 1. Evaluate predictions & capture artefacts
+
+Provide a labelled CSV with a `keyword` column and a ground-truth intent column (default name: `expected_intent`). Then run:
+
+```bash
+python -m cluster.evaluation labelled_keywords.csv --truth-column expected_intent --output-dir reports
+```
+
+The command writes two artefacts under the chosen output directory:
+
+* `misclassified_examples.csv` – rows where the predicted intent differs from the supplied truth. Columns include the original keyword, normalised form, predicted intent/confidence, extracted tags, and cluster context.
+* `novel_tokens.json` – a structured report containing:
+  * Empty `BRANDS`, `MODIFIERS`, and `REGIONS` arrays ready for reviewed additions.
+  * `UNMAPPED_TOKENS` and `UNMAPPED_PHRASES` lists summarising unknown vocabulary with counts and sample keywords to help review.
+
+Use `--min-sim`, `--min-token-count`, and `--min-phrase-count` to tune the evaluation if needed. Runtime brand/modifier/region overrides can still be provided through `--config` or by pointing to an alternate lexicon with `--lexicon`.
+
+### 2. Review `novel_tokens.json`
+
+Inspect the `UNMAPPED_*` sections and decide which entries should extend the lexicon. Promote approved items into the appropriate top-level arrays:
+
+```json
+{
+  "BRANDS": [
+    {"alias": "betway gh", "canonical": "betway"},
+    "mybet"
+  ],
+  "MODIFIERS": ["sports picks"],
+  "REGIONS": ["nigeria"],
+  "UNMAPPED_TOKENS": [...],
+  "UNMAPPED_PHRASES": [...]
+}
+```
+
+* Brand entries can be either strings (alias equals canonical form) or objects with explicit `alias`/`canonical` keys for synonym mapping.
+* Modifiers and regions are simple strings. All values are normalised to lower-case when applied.
+
+Leave unapproved candidates in the `UNMAPPED_*` sections for later review.
+
+### 3. Append reviewed tokens to the shared lexicon
+
+Run the updater to merge the reviewed entries into `cluster/lexicon.json` while avoiding duplicates:
+
+```bash
+python update_lexicon.py --tokens reports/novel_tokens.json
+```
+
+Add `--dry-run` to preview the changes without writing to disk. The script reports which brands, modifiers, and regions were appended. Subsequent runs of the pipeline automatically pick up the refreshed lexicon.
+
+After applying updates you can clear the promoted entries from `novel_tokens.json` (optional) to keep the review queue tidy.
+
+## Lexicon structure
+
+The canonical lexicon lives at `cluster/lexicon.json`. It stores:
+
+* `BRANDS`: alias → canonical mappings used during keyword normalisation.
+* `MODIFIERS`: phrases matched as modifiers.
+* `REGIONS`: supported geographies.
+
+The pipeline loads this file on each execution, so committed changes take effect immediately. You can still provide ad-hoc overrides via the existing `--config` argument when running the pipeline.

--- a/cluster/evaluation.py
+++ b/cluster/evaluation.py
@@ -1,0 +1,214 @@
+import argparse
+import json
+import re
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+import pandas as pd
+
+from .pipeline import prepare_lexicon, process_dataframe
+
+
+def _collect_novel_candidates(
+    df: pd.DataFrame,
+    brands: Dict[str, str],
+    modifiers: Sequence[str],
+    regions: Sequence[str],
+    min_token_count: int = 1,
+    min_phrase_count: int = 2,
+) -> Tuple[List[Dict], List[Dict]]:
+    """Derive token and phrase candidates that are not in the current lexicon."""
+
+    brand_vocab = {b.lower() for b in brands.keys()} | {b.lower() for b in brands.values()}
+    modifier_vocab = {m.lower() for m in modifiers}
+    region_vocab = {r.lower() for r in regions}
+    known_phrases = {m for m in modifier_vocab if " " in m}
+
+    token_counts: Counter = Counter()
+    token_examples: Dict[str, set] = defaultdict(set)
+    phrase_counts: Counter = Counter()
+    phrase_examples: Dict[str, set] = defaultdict(set)
+
+    for original, normalized in zip(df["keyword"], df["keyword_norm"]):
+        tokens = [tok for tok in str(normalized).split() if tok]
+        for tok in tokens:
+            if not re.search(r"[a-z]", tok):
+                continue
+            token_counts[tok] += 1
+            if len(token_examples[tok]) < 5:
+                token_examples[tok].add(str(original))
+        for n in (2, 3):
+            if len(tokens) < n:
+                continue
+            for i in range(len(tokens) - n + 1):
+                phrase = " ".join(tokens[i : i + n])
+                phrase_counts[phrase] += 1
+                if len(phrase_examples[phrase]) < 5:
+                    phrase_examples[phrase].add(str(original))
+
+    novel_tokens: List[Dict] = []
+    for token, count in sorted(token_counts.items(), key=lambda x: (-x[1], x[0])):
+        if token in brand_vocab or token in modifier_vocab or token in region_vocab:
+            continue
+        if count < min_token_count:
+            continue
+        examples = sorted(token_examples[token])
+        novel_tokens.append(
+            {
+                "token": token,
+                "count": int(count),
+                "example_keywords": examples,
+            }
+        )
+
+    novel_phrases: List[Dict] = []
+    for phrase, count in sorted(phrase_counts.items(), key=lambda x: (-x[1], x[0])):
+        if phrase in known_phrases:
+            continue
+        tokens = phrase.split()
+        if all(tok in brand_vocab or tok in modifier_vocab or tok in region_vocab for tok in tokens):
+            continue
+        if count < min_phrase_count:
+            continue
+        examples = sorted(phrase_examples[phrase])
+        novel_phrases.append(
+            {
+                "phrase": phrase,
+                "count": int(count),
+                "example_keywords": examples,
+            }
+        )
+
+    return novel_tokens, novel_phrases
+
+
+def evaluate_dataset(
+    csv_in: str,
+    truth_column: str = "expected_intent",
+    output_dir: str = "reports",
+    min_sim: float = 0.8,
+    config_path: str = None,
+    lexicon_path: str = None,
+    min_token_count: int = 1,
+    min_phrase_count: int = 2,
+) -> Dict:
+    """Run the pipeline on labelled data and capture evaluation artefacts."""
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    df = pd.read_csv(csv_in)
+    if truth_column not in df.columns:
+        raise ValueError(f"Expected column '{truth_column}' in evaluation dataset.")
+
+    brands, modifiers, regions = prepare_lexicon(config_path=config_path, lexicon_path=lexicon_path)
+    processed = process_dataframe(df, min_sim=min_sim, lexicon=(brands, modifiers, regions))
+    processed = processed.rename(
+        columns={
+            "intent": "predicted_intent",
+            "intent_conf": "predicted_intent_conf",
+        }
+    )
+    processed[truth_column] = df[truth_column]
+
+    comparison = processed.copy()
+    misclassified = comparison[comparison["predicted_intent"] != comparison[truth_column]]
+
+    misclassified_path = output_path / "misclassified_examples.csv"
+    columns = [
+        col
+        for col in [
+            "keyword",
+            "keyword_norm",
+            truth_column,
+            "predicted_intent",
+            "predicted_intent_conf",
+            "brands",
+            "regions",
+            "modifiers",
+            "cluster_id",
+            "centroid",
+            "avg_sim",
+        ]
+        if col in misclassified.columns
+    ]
+    misclassified[columns].to_csv(misclassified_path, index=False)
+
+    novel_tokens, novel_phrases = _collect_novel_candidates(
+        processed,
+        brands=brands,
+        modifiers=modifiers,
+        regions=regions,
+        min_token_count=min_token_count,
+        min_phrase_count=min_phrase_count,
+    )
+
+    novel_output = {
+        "metadata": {
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "source_csv": str(csv_in),
+            "truth_column": truth_column,
+            "total_rows": int(len(processed)),
+            "misclassified_rows": int(len(misclassified)),
+            "accuracy": (
+                float((len(processed) - len(misclassified)) / len(processed))
+                if len(processed)
+                else None
+            ),
+        },
+        "BRANDS": [],
+        "MODIFIERS": [],
+        "REGIONS": [],
+        "UNMAPPED_TOKENS": novel_tokens,
+        "UNMAPPED_PHRASES": novel_phrases,
+    }
+
+    novel_path = output_path / "novel_tokens.json"
+    with open(novel_path, "w") as f:
+        json.dump(novel_output, f, indent=2, ensure_ascii=False)
+
+    accuracy = novel_output["metadata"]["accuracy"]
+
+    return {
+        "total_rows": len(processed),
+        "misclassified_rows": len(misclassified),
+        "accuracy": accuracy,
+        "misclassified_path": str(misclassified_path),
+        "novel_tokens_path": str(novel_path),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate clustering/intent predictions")
+    parser.add_argument("csv_in", help="CSV file with labelled keywords")
+    parser.add_argument("--truth-column", default="expected_intent")
+    parser.add_argument("--output-dir", default="reports")
+    parser.add_argument("--min-sim", type=float, default=0.8)
+    parser.add_argument("--config", dest="config_path")
+    parser.add_argument("--lexicon", dest="lexicon_path")
+    parser.add_argument("--min-token-count", type=int, default=1)
+    parser.add_argument("--min-phrase-count", type=int, default=2)
+    args = parser.parse_args()
+
+    summary = evaluate_dataset(
+        csv_in=args.csv_in,
+        truth_column=args.truth_column,
+        output_dir=args.output_dir,
+        min_sim=args.min_sim,
+        config_path=args.config_path,
+        lexicon_path=args.lexicon_path,
+        min_token_count=args.min_token_count,
+        min_phrase_count=args.min_phrase_count,
+    )
+
+    accuracy = summary["accuracy"]
+    accuracy_msg = "N/A" if accuracy is None else f"{accuracy:.3f}"
+    print(f"Processed {summary['total_rows']} rows | accuracy={accuracy_msg}")
+    print(f"Misclassified examples -> {summary['misclassified_path']}")
+    print(f"Novel token candidates -> {summary['novel_tokens_path']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cluster/lexicon.json
+++ b/cluster/lexicon.json
@@ -1,0 +1,35 @@
+{
+  "BRANDS": {
+    "betway": "betway",
+    "sportybet": "sportybet",
+    "msport": "msport",
+    "betpawa": "betpawa",
+    "betika": "betika"
+  },
+  "MODIFIERS": [
+    "app",
+    "apk",
+    "login",
+    "register",
+    "bonus",
+    "odds",
+    "fixtures",
+    "live",
+    "tips",
+    "predictions",
+    "jackpot",
+    "casino",
+    "slots",
+    "live dealer",
+    "cashout",
+    "bet builder"
+  ],
+  "REGIONS": [
+    "ghana",
+    "south africa",
+    "botswana",
+    "zambia",
+    "tanzania",
+    "mozambique"
+  ]
+}

--- a/cluster/pipeline.py
+++ b/cluster/pipeline.py
@@ -1,35 +1,114 @@
 import json
-import pandas as pd
 import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-# --- domain dictionaries you can extend ---
-BRANDS = {
-    "betway": "betway", "sportybet": "sportybet", "msport": "msport",
-    "betpawa": "betpawa", "betika": "betika"
-}
-MODIFIERS = [
-    "app","apk","login","register","bonus","odds","fixtures","live",
-    "tips","predictions","jackpot","casino","slots","live dealer",
-    "cashout","bet builder"
-]
-REGIONS = ["ghana","south africa","botswana","zambia","tanzania","mozambique"]
+DEFAULT_LEXICON_PATH = Path(__file__).with_name("lexicon.json")
 
-def normalize_kw(s: str) -> str:
-    s = s.lower()
-    s = re.sub(r"[^a-z0-9\s\-&]", " ", s)
-    s = re.sub(r"\s+", " ", s).strip()
-    for k, v in BRANDS.items():
-        s = re.sub(rf"\b{k}\b", v, s)
-    return s
 
-def extract_tags(s: str):
-    toks = s.split()
-    brands = [b for b in BRANDS if b in toks]
-    regions = [r for r in REGIONS if r in s]
-    modifiers = [m for m in MODIFIERS if re.search(rf"\b{re.escape(m)}\b", s)]
-    return brands, regions, modifiers
+def load_lexicon(path: Path = DEFAULT_LEXICON_PATH) -> Tuple[Dict[str, str], List[str], List[str]]:
+    """Load the brand/modifier/region lexicon from disk."""
+    with open(path) as f:
+        data = json.load(f)
+
+    brands = {k.lower(): v.lower() for k, v in data.get("BRANDS", {}).items()}
+    modifiers = [m.lower() for m in data.get("MODIFIERS", [])]
+    regions = [r.lower() for r in data.get("REGIONS", [])]
+    return brands, modifiers, regions
+
+
+def merge_lexicon(
+    brands: Dict[str, str],
+    modifiers: Sequence[str],
+    regions: Sequence[str],
+    updates: Dict[str, Iterable],
+) -> Tuple[Dict[str, str], List[str], List[str]]:
+    """Merge runtime updates with the base lexicon without creating duplicates."""
+
+    merged_brands = dict(brands)
+    for alias, canonical in updates.get("BRANDS", {}).items():
+        alias_norm = str(alias).lower()
+        canonical_norm = str(canonical).lower()
+        merged_brands[alias_norm] = canonical_norm
+        if canonical_norm not in merged_brands:
+            merged_brands[canonical_norm] = canonical_norm
+
+    merged_modifiers: List[str] = list(modifiers)
+    for modifier in updates.get("MODIFIERS", []):
+        mod_norm = str(modifier).lower()
+        if mod_norm not in merged_modifiers:
+            merged_modifiers.append(mod_norm)
+
+    merged_regions: List[str] = list(regions)
+    for region in updates.get("REGIONS", []):
+        region_norm = str(region).lower()
+        if region_norm not in merged_regions:
+            merged_regions.append(region_norm)
+
+    return merged_brands, merged_modifiers, merged_regions
+
+
+def prepare_lexicon(config_path: str = None, lexicon_path: str = None):
+    """Load the base lexicon and apply optional runtime configuration."""
+
+    path = Path(lexicon_path) if lexicon_path else DEFAULT_LEXICON_PATH
+    brands, modifiers, regions = load_lexicon(path)
+
+    if config_path:
+        with open(config_path) as f:
+            updates = json.load(f)
+        brands, modifiers, regions = merge_lexicon(brands, modifiers, regions, updates)
+
+    return brands, modifiers, regions
+
+
+BRANDS, MODIFIERS, REGIONS = load_lexicon()
+
+
+def normalize_kw(s: str, brands: Dict[str, str] = None) -> str:
+    brands = brands or BRANDS
+    text = str(s).lower()
+    text = re.sub(r"[^a-z0-9\s\-&]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    for alias, canonical in brands.items():
+        text = re.sub(rf"\b{re.escape(alias)}\b", canonical, text)
+    return text
+
+
+def extract_tags(
+    s: str,
+    brands: Dict[str, str] = None,
+    regions: Iterable[str] = None,
+    modifiers: Iterable[str] = None,
+):
+    brands = brands or BRANDS
+    regions = list(regions or REGIONS)
+    modifiers = list(modifiers or MODIFIERS)
+
+    toks = str(s).split()
+    brand_hits: List[str] = []
+    for tok in toks:
+        if tok in brands:
+            canonical = brands[tok]
+            if canonical not in brand_hits:
+                brand_hits.append(canonical)
+
+    text = str(s)
+    region_hits: List[str] = []
+    for region in regions:
+        if region in text and region not in region_hits:
+            region_hits.append(region)
+
+    modifier_hits: List[str] = []
+    for modifier in modifiers:
+        if re.search(rf"\b{re.escape(modifier)}\b", text):
+            modifier_hits.append(modifier)
+
+    return brand_hits, region_hits, modifier_hits
 
 def cluster_keywords(keywords: list, min_sim=0.8) -> pd.DataFrame:
     vec = TfidfVectorizer(analyzer="char", ngram_range=(3,5))
@@ -78,26 +157,44 @@ def classify_intent(text: str):
     conf = min(0.9, 0.5 + 0.1*len(scores))
     return label, conf
 
-def run_pipeline(csv_in, csv_out, min_sim=0.8, config_path=None):
-    if config_path:
-        with open(config_path) as f:
-            cfg = json.load(f)
-        BRANDS.update(cfg.get("BRANDS", {}))
-        MODIFIERS.extend([m for m in cfg.get("MODIFIERS", []) if m not in MODIFIERS])
-        REGIONS.extend([r for r in cfg.get("REGIONS", []) if r not in REGIONS])
+def process_dataframe(
+    df: pd.DataFrame,
+    min_sim: float = 0.8,
+    lexicon: Tuple[Dict[str, str], Sequence[str], Sequence[str]] = None,
+) -> pd.DataFrame:
+    """Run the clustering pipeline against an in-memory dataframe."""
 
-    df = pd.read_csv(csv_in)
     if "keyword" not in df.columns:
         raise ValueError("Input CSV must have a 'keyword' column.")
-    df["keyword_norm"] = df["keyword"].apply(normalize_kw)
-    tags = df["keyword_norm"].apply(extract_tags)
-    df[["brands","regions","modifiers"]] = pd.DataFrame(tags.tolist(), index=df.index)
-    cl = cluster_keywords(df["keyword_norm"].tolist(), min_sim=min_sim)
-    df = df.merge(cl, on="keyword_norm", how="left")
-    intents = df["keyword_norm"].apply(classify_intent)
-    df["intent"] = intents.apply(lambda x: x[0])
-    df["intent_conf"] = intents.apply(lambda x: x[1])
-    df.to_csv(csv_out, index=False)
+
+    brands, modifiers, regions = lexicon or (BRANDS, MODIFIERS, REGIONS)
+    brands = dict(brands)
+    modifiers = list(modifiers)
+    regions = list(regions)
+
+    result = df.copy()
+    result["keyword_norm"] = result["keyword"].apply(lambda x: normalize_kw(x, brands=brands))
+    tags = result["keyword_norm"].apply(
+        lambda text: extract_tags(text, brands=brands, regions=regions, modifiers=modifiers)
+    )
+    result[["brands", "regions", "modifiers"]] = pd.DataFrame(tags.tolist(), index=result.index)
+
+    clusters = cluster_keywords(result["keyword_norm"].tolist(), min_sim=min_sim)
+    result = result.merge(clusters, on="keyword_norm", how="left")
+
+    intents = result["keyword_norm"].apply(classify_intent)
+    result["intent"] = intents.apply(lambda x: x[0])
+    result["intent_conf"] = intents.apply(lambda x: x[1])
+
+    return result
+
+
+def run_pipeline(csv_in, csv_out, min_sim=0.8, config_path=None, lexicon_path=None):
+    brands, modifiers, regions = prepare_lexicon(config_path=config_path, lexicon_path=lexicon_path)
+
+    df = pd.read_csv(csv_in)
+    result = process_dataframe(df, min_sim=min_sim, lexicon=(brands, modifiers, regions))
+    result.to_csv(csv_out, index=False)
 
 if __name__ == "__main__":
     import argparse
@@ -106,5 +203,12 @@ if __name__ == "__main__":
     parser.add_argument("csv_out")
     parser.add_argument("--min-sim", type=float, default=0.8)
     parser.add_argument("--config", dest="config_path")
+    parser.add_argument("--lexicon", dest="lexicon_path")
     args = parser.parse_args()
-    run_pipeline(args.csv_in, args.csv_out, min_sim=args.min_sim, config_path=args.config_path)
+    run_pipeline(
+        args.csv_in,
+        args.csv_out,
+        min_sim=args.min_sim,
+        config_path=args.config_path,
+        lexicon_path=args.lexicon_path,
+    )

--- a/update_lexicon.py
+++ b/update_lexicon.py
@@ -1,0 +1,163 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from cluster.pipeline import DEFAULT_LEXICON_PATH, load_lexicon, merge_lexicon
+
+
+def _normalize_brand_updates(raw) -> Dict[str, str]:
+    updates: Dict[str, str] = {}
+    if isinstance(raw, dict):
+        iterable = raw.items()
+    elif isinstance(raw, list):
+        iterable = []
+        for entry in raw:
+            if isinstance(entry, dict):
+                alias = entry.get("alias")
+                canonical = entry.get("canonical", alias)
+                if alias:
+                    iterable.append((alias, canonical))
+            else:
+                iterable.append((entry, entry))
+    elif raw is None:
+        iterable = []
+    else:
+        iterable = [(raw, raw)]
+
+    for alias, canonical in iterable:
+        if alias is None:
+            continue
+        alias_str = str(alias).strip()
+        if not alias_str:
+            continue
+        canonical_str = str(canonical if canonical is not None else alias).strip()
+        if not canonical_str:
+            canonical_str = alias_str
+        updates[alias_str] = canonical_str
+    return updates
+
+
+def _normalize_list_updates(raw: Iterable) -> List[str]:
+    values: List[str] = []
+    if raw is None:
+        return values
+    if isinstance(raw, dict):
+        raw = raw.values()
+    for item in raw:
+        if item is None:
+            continue
+        val = str(item).strip()
+        if val:
+            values.append(val)
+    return values
+
+
+def _write_lexicon(path: Path, brands: Dict[str, str], modifiers: List[str], regions: List[str]) -> None:
+    ordered_brands = {k.lower(): brands[k].lower() for k in sorted(brands)}
+    ordered_modifiers = sorted({m.lower() for m in modifiers})
+    ordered_regions = sorted({r.lower() for r in regions})
+
+    data = {
+        "BRANDS": ordered_brands,
+        "MODIFIERS": ordered_modifiers,
+        "REGIONS": ordered_regions,
+    }
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def update_lexicon(lexicon_path: Path, tokens_path: Path, dry_run: bool = False) -> Dict:
+    if not tokens_path.exists():
+        raise FileNotFoundError(f"Token file not found: {tokens_path}")
+
+    tokens = json.loads(tokens_path.read_text())
+    brand_updates = _normalize_brand_updates(tokens.get("BRANDS"))
+    modifier_updates = _normalize_list_updates(tokens.get("MODIFIERS"))
+    region_updates = _normalize_list_updates(tokens.get("REGIONS"))
+
+    updates = {
+        "BRANDS": brand_updates,
+        "MODIFIERS": modifier_updates,
+        "REGIONS": region_updates,
+    }
+
+    if not any(updates.values()):
+        return {
+            "updated": False,
+            "brands_added": [],
+            "modifiers_added": [],
+            "regions_added": [],
+        }
+
+    base_brands, base_modifiers, base_regions = load_lexicon(lexicon_path)
+
+    new_brands, new_modifiers, new_regions = merge_lexicon(
+        base_brands,
+        base_modifiers,
+        base_regions,
+        updates,
+    )
+
+    brand_deltas = []
+    for alias, canonical in brand_updates.items():
+        alias_norm = alias.lower()
+        canonical_norm = canonical.lower()
+        if base_brands.get(alias_norm) != canonical_norm:
+            brand_deltas.append({"alias": alias_norm, "canonical": canonical_norm})
+
+    existing_modifiers = {m.lower() for m in base_modifiers}
+    modifier_deltas = [m.lower() for m in modifier_updates if m.lower() not in existing_modifiers]
+
+    existing_regions = {r.lower() for r in base_regions}
+    region_deltas = [r.lower() for r in region_updates if r.lower() not in existing_regions]
+
+    if not dry_run:
+        _write_lexicon(lexicon_path, new_brands, new_modifiers, new_regions)
+
+    return {
+        "updated": True,
+        "brands_added": brand_deltas,
+        "modifiers_added": modifier_deltas,
+        "regions_added": region_deltas,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Append reviewed tokens to the shared lexicon")
+    parser.add_argument(
+        "--lexicon",
+        type=Path,
+        default=DEFAULT_LEXICON_PATH,
+        help="Path to lexicon JSON (defaults to cluster/lexicon.json)",
+    )
+    parser.add_argument(
+        "--tokens",
+        type=Path,
+        default=Path("reports/novel_tokens.json"),
+        help="Reviewed token file produced by cluster.evaluation",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without writing")
+    args = parser.parse_args()
+
+    summary = update_lexicon(args.lexicon, args.tokens, dry_run=args.dry_run)
+    if not summary["updated"]:
+        print("No updates applied; please populate BRANDS/MODIFIERS/REGIONS in the token file.")
+        return
+
+    print("Lexicon updated" if not args.dry_run else "Lexicon diff (dry run)")
+    if summary["brands_added"]:
+        print("  Brands:")
+        for entry in summary["brands_added"]:
+            print(f"    {entry['alias']} -> {entry['canonical']}")
+    if summary["modifiers_added"]:
+        print("  Modifiers:")
+        for modifier in summary["modifiers_added"]:
+            print(f"    {modifier}")
+    if summary["regions_added"]:
+        print("  Regions:")
+        for region in summary["regions_added"]:
+            print(f"    {region}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- load brand/modifier/region data from a shared lexicon file and refactor the pipeline for reuse
- add an evaluation command that saves misclassified keywords and records novel token candidates
- provide an update_lexicon utility plus documentation for reviewing and applying lexicon changes

## Testing
- python -m compileall cluster update_lexicon.py

------
https://chatgpt.com/codex/tasks/task_e_68c97d3d4e8c8321a660b8ec8116a78c